### PR TITLE
Support Large Files

### DIFF
--- a/src/bhcli/api/__init__.py
+++ b/src/bhcli/api/__init__.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import hashlib
 import hmac
+import io
 import json
 import time
 import urllib
@@ -64,7 +65,12 @@ class Api:
             digester.update(datetime_formatted[:13].encode())
             digester = hmac.new(digester.digest(), None, hashlib.sha256)
             if data is not None:
-                digester.update(data)
+                if isinstance(data, io.BufferedIOBase):
+                    for chunk in iter(lambda: data.read(65536), b""):
+                        digester.update(chunk)
+                    data.seek(0)
+                else:
+                    digester.update(data)
             headers["Authorization"] = f"bhesignature {self._token_id}"
             headers["RequestDate"] = datetime_formatted
             headers["Signature"] = base64.b64encode(digester.digest())

--- a/src/bhcli/cli/upload.py
+++ b/src/bhcli/cli/upload.py
@@ -35,10 +35,9 @@ def upload(files):
         else:
             log.warning("File of unsupported type will be ignored: %s", file)
             continue
-        with open(file, "rb") as f:
-            content = f.read()
         log.info("Uploading file %s", file)
-        api.upload_file(upload_id, content, content_type)
+        with open(file, "rb") as f:
+            api.upload_file(upload_id, f, content_type)
 
     log.info("Ending file upload job...")
     api.end_upload(upload_id)


### PR DESCRIPTION
### Summary

1. File uploads previously read the entire file into memory with f.read() before POSTing, causing `socket.send()` to fail on large files.
2. Now passes the open file handle directly to requests, which streams the body in chunks.
3. HMAC-SHA256 signing is preserved by hashing the file incrementally (64 KB chunks) before seeking back to 0.

### Test plan

- [x]  pytest passes
- [x]  Upload a large ZIP file (`bhcli upload large.zip`) and confirm it completes without a socket/buffer error