### PR TITLE
Seek file to start before hashing so 429 retries sign correctly

### DIFF
--- a/src/bhcli/api/__init__.py
+++ b/src/bhcli/api/__init__.py
@@ -66,6 +66,8 @@ class Api:
             digester = hmac.new(digester.digest(), None, hashlib.sha256)
             if data is not None:
                 if isinstance(data, io.BufferedIOBase):
+                    # Seek to the start *before hashing, so the first attempt and any retry are retry-safe
+                    data.seek(0)
                     for chunk in iter(lambda: data.read(65536), b""):
                         digester.update(chunk)
                     data.seek(0)


### PR DESCRIPTION
This PR fixes a bug introduced in PR #15 in the file upload feature
When a signed upload hits a rate limit `429`, `_send` retries, but `requests` has already consumed the file body to EOF, so without a `data.seek(0)` before hashing, the retry signs an empty body and authentication fails.